### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 0.1.0 (2024-07-12)
+
+
+### Generic
+
+* **slice:** Add new generic slice data type ([eb32e5a](https://github.com/mushoffa/gorengan/commit/eb32e5a17b224ce4e97c15e2ca3e4ff7a0e2df8f))
+
+
+### Image
+
+* Add new extension of std image pkg with additional conversion function ([aa0d60b](https://github.com/mushoffa/gorengan/commit/aa0d60b4a779c87bcd39fca9726d5195f6e475a7))
+
+
+### Documentation
+
+* **readme:** Add description and getting started stuffs ([e6cb9ed](https://github.com/mushoffa/gorengan/commit/e6cb9ed13c0ed26ff48a338b5516b187b3f1657d))
+
+
+### Build System
+
+* Add go.mod ([0fd1ed9](https://github.com/mushoffa/gorengan/commit/0fd1ed9c9c3cefdf7a10c672d0e3dd5d81562e92))
+* Customize standard version section type ([601378d](https://github.com/mushoffa/gorengan/commit/601378dc709d89c2aef7a3e3ef7708243dd25c85))


### PR DESCRIPTION
## 0.1.0 (2024-07-12)


### Generic

* **slice:** Add new generic slice data type ([eb32e5a](https://github.com/mushoffa/gorengan/commit/eb32e5a17b224ce4e97c15e2ca3e4ff7a0e2df8f))


### Image

* Add new extension of std image pkg with additional conversion function ([aa0d60b](https://github.com/mushoffa/gorengan/commit/aa0d60b4a779c87bcd39fca9726d5195f6e475a7))


### Documentation

* **readme:** Add description and getting started stuffs ([e6cb9ed](https://github.com/mushoffa/gorengan/commit/e6cb9ed13c0ed26ff48a338b5516b187b3f1657d))


### Build System

* Add go.mod ([0fd1ed9](https://github.com/mushoffa/gorengan/commit/0fd1ed9c9c3cefdf7a10c672d0e3dd5d81562e92))
* Customize standard version section type ([601378d](https://github.com/mushoffa/gorengan/commit/601378dc709d89c2aef7a3e3ef7708243dd25c85))