### PR TITLE
chore(release): 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.2](https://github.com/mushoffa/gorengan/compare/v0.7.1...v0.7.2) (2024-08-01)
+
+
+### Bug Fixes
+
+* **image:** Expose field Data of Image struct ([edacc4e](https://github.com/mushoffa/gorengan/commit/edacc4e7373c38929734bf3e336d9694b8f797ba))
+
 ### [0.7.1](https://github.com/mushoffa/gorengan/compare/v0.7.0...v0.7.1) (2024-08-01)
 
 

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 
 package gorengan
 
-const Version = "v0.7.1"
+const Version = "v0.7.2"


### PR DESCRIPTION
### Bug Fixes

* **image:** Expose field Data of Image struct ([edacc4e](https://github.com/mushoffa/gorengan/commit/edacc4e7373c38929734bf3e336d9694b8f797ba))